### PR TITLE
feat: resolve `elide` from `PATH`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Configuring Elide as your `javac` compiler:
 Properties needed:
 ```xml
     <properties>
-        <maven.compiler.executable>/path/to/elide</maven.compiler.executable>
         <maven.compiler.source>24</maven.compiler.source>
         <maven.compiler.target>24</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/sample/README.md
+++ b/sample/README.md
@@ -24,13 +24,3 @@ code to build, and the `pom.xml` is configured to use Elide.
         </plugins>
     </build>
 ```
-
-Properties needed:
-```xml
-    <properties>
-        <maven.compiler.executable>/path/to/elide</maven.compiler.executable>
-        <maven.compiler.source>24</maven.compiler.source>
-        <maven.compiler.target>24</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-```

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -5,7 +5,6 @@
     <version>1</version>
 
     <properties>
-        <maven.compiler.executable>/home/sam/bin/elide</maven.compiler.executable>
         <maven.compiler.source>24</maven.compiler.source>
         <maven.compiler.target>24</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/kotlin/dev/elide/maven/compiler/Constants.kt
+++ b/src/main/kotlin/dev/elide/maven/compiler/Constants.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package dev.elide.maven.compiler
+
+/**
+ * Constant ID used by the Elide compiler shim.
+ */
+public const val ELIDE_COMPILER: String = "elide"

--- a/src/main/kotlin/dev/elide/maven/compiler/ElideLocator.kt
+++ b/src/main/kotlin/dev/elide/maven/compiler/ElideLocator.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package dev.elide.maven.compiler
+
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Locates the Elide binary via the user's PATH.
+ *
+ * @author Sam Gammon <sgammon>
+ * @since 1.0.0
+ */
+object ElideLocator {
+    // Checks if a path is a valid binary.
+    private fun isValidElideBinary(path: Path): Boolean {
+        return path.toFile().exists() && path.toFile().isFile && path.toFile().canExecute()
+    }
+
+    /**
+     * Attempts to locate the Elide binary in the user's PATH.
+     *
+     * @return The path to the Elide binary, or null if not found.
+     */
+    fun locate(): Path? {
+        val path = System.getenv("PATH") ?: ""
+        for (pathCandidate in path.split(File.separatorChar)) {
+            val candidate = Paths.get(pathCandidate, "elide")
+            if (isValidElideBinary(candidate)) {
+                return candidate
+            }
+        }
+        return null
+    }
+}


### PR DESCRIPTION
### Summary

Adds `PATH` resolution for the Elide binary, which kicks in by default; if `maven.compiler.executable` is specified, it will be used, otherwise this new logic will apply.

#1 should be merged first, and then this should be rebased, before merging (or, this should be merged and that PR should be closed).

### Changelog
```
feat: use compiler path if specified (overrides)
feat: resolve `elide` from user path
chore: cleanups in readme/sample project
chore: move compiler ID to new constants file
```